### PR TITLE
If user is not logged in, operator redirects to login page

### DIFF
--- a/public/script/operator.js
+++ b/public/script/operator.js
@@ -197,7 +197,7 @@
             // TODO: use JStoken to verify if user looking at this page is an admin
             // force user to leave page if they are not coming there through the login page.
             if (!params.user) {
-                window.location.href = "http://localhost:3500/view/not-found"
+                window.location.href = "/view/login"
             }
             
             // Get the value of "some_key" in eg "https://example.com/?some_key=some_value"


### PR DESCRIPTION
Was previously hard-coded to the localhost 404 page, which couldn't work online. Changed to relative link, and redirected to login instead.